### PR TITLE
fixed wrong camera center

### DIFF
--- a/gaussian-splatting/scene/cameras.py
+++ b/gaussian-splatting/scene/cameras.py
@@ -103,4 +103,4 @@ class CustomCam:
         self.full_proj_transform = (
             self.world_view_transform.unsqueeze(0).bmm(self.projection_matrix.unsqueeze(0))
         ).squeeze(0)
-        self.camera_center = -self.full_proj_transform[:3, -1]
+        self.camera_center = self.world_view_transform.inverse()[3, :3]


### PR DESCRIPTION
`self.camera_center = -self.full_proj_transform[:3, -1]` 
for the CustomCam was wrong, I fixed it. This is evident when sorting using the distance to the camera directly.